### PR TITLE
fix(readme): Fix broken links to spring boot auto-configure project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@
 ## Links
 
 * [Temporal Java SDK](https://github.com/temporalio/sdk-java)
-* [Spring Boot Integration package](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha)
+* [Spring Boot Integration package](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure)
 
 ## Intro
 
 This demo showcases Temporal Java SDK integration with Spring Boot.
-It uses the [Java SDK Spring Boot AutoConfig](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha).
+It uses the [Java SDK Spring Boot AutoConfig](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure).
 
 Shown features:
-* [Connection Setup](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#connection-setup)
-* [Workflows and Activities auto-discovery](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#auto-discovery)
-* [Data converter auto-discovery](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#data-converter)
-* [Integration with Metrics (Prometheus)](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#metrics)
-* [Integration with Tracing (Jaeger)](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#tracing)
-* [Testing](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#testing)
-* (todo) [mTLS](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure-alpha#mtls)
+* [Connection Setup](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#connection-setup)
+* [Workflows and Activities auto-discovery](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#auto-discovery)
+* [Data converter auto-discovery](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#data-converter)
+* [Integration with Metrics (Prometheus)](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#metrics)
+* [Integration with Tracing (Jaeger)](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#tracing)
+* [Testing](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#testing)
+* (todo) [mTLS](https://github.com/temporalio/sdk-java/tree/master/temporal-spring-boot-autoconfigure#mtls)
 
 ## Run Demo
 


### PR DESCRIPTION
## What was changed
Fixed broken links to `temporal-spring-boot-autoconfigure`.

## Why?
I noticed the links were broken since the project got renamed.
